### PR TITLE
Prevent URL Double Encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `block_blc_modules` for Moodle 4.5 are documented in this
 
 ---
 
+## [4.5.16] — 2026-06-10
+
+### Fixed
+- Double URL encoding in API calls that pass `scormurl` through `moodle_url`, which could break communication with the BLC API server.
+
+---
+
 ## [4.5.15] — 2026-06-09
 
 ### Fixed
@@ -217,20 +224,21 @@ All notable changes to `block_blc_modules` for Moodle 4.5 are documented in this
 
 ---
 
-[4.5.15]: https://github.com/terus-technology/moodle-block_blc_modules/compare/v4.5.14...v4.5.15
-[4.5.14]: https://github.com/terus-technology/moodle-block_blc_modules/compare/v4.5.13...v4.5.14
-[4.5.13]: https://github.com/terus-technology/moodle-block_blc_modules/compare/v4.5.12...v4.5.13
-[4.5.12]: https://github.com/terus-technology/moodle-block_blc_modules/compare/v4.5.11...v4.5.12
-[4.5.11]: https://github.com/terus-technology/moodle-block_blc_modules/compare/v4.5.10...v4.5.11
-[4.5.10]: https://github.com/terus-technology/moodle-block_blc_modules/compare/v4.5.9...v4.5.10
-[4.5.9]: https://github.com/terus-technology/moodle-block_blc_modules/compare/v4.5.8...v4.5.9
-[4.5.8]: https://github.com/terus-technology/moodle-block_blc_modules/compare/v4.5.7...v4.5.8
-[4.5.7]: https://github.com/terus-technology/moodle-block_blc_modules/compare/v4.5.6...v4.5.7
-[4.5.6]: https://github.com/terus-technology/moodle-block_blc_modules/compare/v4.5.5...v4.5.6
-[4.5.5]: https://github.com/terus-technology/moodle-block_blc_modules/compare/v4.5.4...v4.5.5
-[4.5.4]: https://github.com/terus-technology/moodle-block_blc_modules/compare/v4.5.3...v4.5.4
-[4.5.3]: https://github.com/terus-technology/moodle-block_blc_modules/compare/v4.5.2...v4.5.3
-[4.5.2]: https://github.com/terus-technology/moodle-block_blc_modules/compare/v4.5.1...v4.5.2
-[4.5.1]: https://github.com/terus-technology/moodle-block_blc_modules/compare/v4.5.0...v4.5.1
-[4.5.0]: https://github.com/terus-technology/moodle-block_blc_modules/compare/v1.0.0...v4.5.0
+[4.5.16]: https://github.com/terus-technology/moodle-block_blcmodules/compare/v4.5.15...v4.5.16
+[4.5.15]: https://github.com/terus-technology/moodle-block_blcmodules/compare/v4.5.14...v4.5.15
+[4.5.14]: https://github.com/terus-technology/moodle-block_blcmodules/compare/v4.5.13...v4.5.14
+[4.5.13]: https://github.com/terus-technology/moodle-block_blcmodules/compare/v4.5.12...v4.5.13
+[4.5.12]: https://github.com/terus-technology/moodle-block_blcmodules/compare/v4.5.11...v4.5.12
+[4.5.11]: https://github.com/terus-technology/moodle-block_blcmodules/compare/v4.5.10...v4.5.11
+[4.5.10]: https://github.com/terus-technology/moodle-block_blcmodules/compare/v4.5.9...v4.5.10
+[4.5.9]: https://github.com/terus-technology/moodle-block_blcmodules/compare/v4.5.8...v4.5.9
+[4.5.8]: https://github.com/terus-technology/moodle-block_blcmodules/compare/v4.5.7...v4.5.8
+[4.5.7]: https://github.com/terus-technology/moodle-block_blcmodules/compare/v4.5.6...v4.5.7
+[4.5.6]: https://github.com/terus-technology/moodle-block_blcmodules/compare/v4.5.5...v4.5.6
+[4.5.5]: https://github.com/terus-technology/moodle-block_blcmodules/compare/v4.5.4...v4.5.5
+[4.5.4]: https://github.com/terus-technology/moodle-block_blcmodules/compare/v4.5.3...v4.5.4
+[4.5.3]: https://github.com/terus-technology/moodle-block_blcmodules/compare/v4.5.2...v4.5.3
+[4.5.2]: https://github.com/terus-technology/moodle-block_blcmodules/compare/v4.5.1...v4.5.2
+[4.5.1]: https://github.com/terus-technology/moodle-block_blcmodules/compare/v4.5.0...v4.5.1
+[4.5.0]: https://github.com/terus-technology/moodle-block_blcmodules/compare/v1.0.0...v4.5.0
 [1.0.0]: https://github.com/terus-technology/moodle-block_blc_modules/releases/tag/v1.0.0

--- a/add_doc.php
+++ b/add_doc.php
@@ -195,13 +195,12 @@ if ($blcmodules) {
 
             try {
                 $functionname = 'local_scormurl_get_tempdocurls';
-                $tempurl = urlencode($blcmodule->scormurl);
 
                 $serverurl = new moodle_url($domainname . '/webservice/rest/server.php', [
                     'wstoken' => $token,
                     'wsfunction' => $functionname,
                     'apikey' => $apikey,
-                    'scormurl' => $tempurl,
+                    'scormurl' => $blcmodule->scormurl,
                     'moodlewsrestformat' => 'json',
                 ]);
 
@@ -613,15 +612,12 @@ if ($blcmodules) {
 
             // Cleanup temporary document files on API server.
             try {
-                $cleanuptempurl = urlencode($blcmodule->scormurl);
                 $cleanupfunction = 'local_scormurl_get_deletetempdocurls';
-                $cleanupurl = $domainname . '/webservice/rest/server.php' . '?wstoken=' . $token
-                    . '&wsfunction=' . $cleanupfunction . '&apikey=' . $apikey . '&scormurl=' . $cleanuptempurl;
                 $cleanupurl = new moodle_url($domainname . '/webservice/rest/server.php', [
                     'wstoken' => $token,
                     'wsfunction' => $cleanupfunction,
                     'apikey' => $apikey,
-                    'scormurl' => $cleanuptempurl,
+                    'scormurl' => $blcmodule->scormurl,
                     'moodlewsrestformat' => 'json',
                 ]);
 

--- a/bulk_update_processor.php
+++ b/bulk_update_processor.php
@@ -412,13 +412,12 @@ function perform_bulk_update() {
 
                 // Get temporary URL.
                 $url = $scormurl;
-                $tempurl = urlencode($url);
                 $functionname = 'local_scormurl_get_bulkuptempscormurls';
                 $serverurl = new moodle_url($domainname . '/webservice/rest/server.php', [
                     'wstoken' => $token,
                     'wsfunction' => $functionname,
                     'apikey' => $apikey,
-                    'scormurl' => $tempurl,
+                    'scormurl' => $url,
                 ]);
 
                 add_progress_log("Requesting temp URL for: {$scormname}", 'info');

--- a/classes/external/blcservice.php
+++ b/classes/external/blcservice.php
@@ -404,7 +404,6 @@ class blcservice extends external_api {
 
         foreach ($scormurls as $url) {
             $url = str_replace("’", "'", $url);
-            $tempurl = urlencode($url);
 
             sleep(20);
 
@@ -413,7 +412,7 @@ class blcservice extends external_api {
                 'wstoken' => $token,
                 'wsfunction' => $functionname,
                 'apikey' => $apikey,
-                'scormurl' => $tempurl,
+                'scormurl' => $url,
             ]);
 
             $curl = new blccurl_helper();
@@ -666,19 +665,17 @@ class blcservice extends external_api {
      */
     public static function fetch_scorm_data(string $apikey, string $url, string $token, string $domainname): ?array {
         $functionname = 'local_scormurl_get_tempscormurls';
-        $tempurl = urlencode($url);
         $serverurl = new moodle_url($domainname . '/webservice/rest/server.php', [
             'wstoken' => $token,
             'wsfunction' => $functionname,
             'apikey' => $apikey,
-            'scormurl' => $tempurl,
+            'scormurl' => $url,
             'moodlewsrestformat' => 'json',
         ]);
 
         // Debug: Log the API request.
         debugging('BLC Modules: Calling API: ' . $functionname);
         debugging('BLC Modules: Original URL: ' . $url);
-        debugging('BLC Modules: Encoded URL: ' . $tempurl);
 
         $curl = new blccurl_helper();
         $curl->set_header('Content-Type: application/json; charset=utf-8');
@@ -1186,19 +1183,17 @@ class blcservice extends external_api {
         debugging('BLC Modules: Original SCORM URL: ' . $scormurl);
 
         $functionname = 'local_scormurl_get_tempdocurls';
-        $tempurl = urlencode($scormurl);
         $serverurl = new moodle_url($domainname . '/webservice/rest/server.php', [
             'wstoken' => $token,
             'wsfunction' => $functionname,
             'apikey' => $apikey,
-            'scormurl' => $tempurl,
+            'scormurl' => $scormurl,
             'moodlewsrestformat' => 'json',
         ]);
 
         // Debug: Log the API request.
         debugging('BLC Modules: Calling API: ' . $functionname);
         debugging('BLC Modules: Original URL: ' . $scormurl);
-        debugging('BLC Modules: Encoded URL: ' . $tempurl);
 
         $curl = new blccurl_helper();
         $curl->set_header('Content-Type: application/json; charset=utf-8');
@@ -1334,13 +1329,12 @@ class blcservice extends external_api {
         string $token,
         string $domainname
     ): void {
-        $tempurl = urlencode($url);
         $functionname = 'local_scormurl_get_deletetempscormurls';
         $serverurl = new moodle_url($domainname . '/webservice/rest/server.php', [
             'wstoken' => $token,
             'wsfunction' => $functionname,
             'apikey' => $apikey,
-            'scormurl' => $tempurl,
+            'scormurl' => $url,
             'moodlewsrestformat' => 'json',
         ]);
 
@@ -1358,13 +1352,12 @@ class blcservice extends external_api {
         string $token,
         string $domainname
     ): void {
-        $tempurl = urlencode($url);
         $functionname = 'local_scormurl_get_deletetempdocurls';
         $serverurl = new moodle_url($domainname . '/webservice/rest/server.php', [
             'wstoken' => $token,
             'wsfunction' => $functionname,
             'apikey' => $apikey,
-            'scormurl' => $tempurl,
+            'scormurl' => $url,
             'moodlewsrestformat' => 'json',
         ]);
 

--- a/classes/output/validate_settings_page.php
+++ b/classes/output/validate_settings_page.php
@@ -89,9 +89,8 @@ class validate_settings_page implements renderable, templatable {
         $token = get_config('block_blc_modules', 'token');
         $domainname = get_config('block_blc_modules', 'domainname');
         $requesturi = $CFG->wwwroot;
-
-        // FIXED: Use correct web service function name.
         $functionname = 'local_scormurl_check_scormurls';
+
         $serverurl = new moodle_url($domainname . '/webservice/rest/server.php', [
             'wstoken' => $token,
             'wsfunction' => $functionname,

--- a/version.php
+++ b/version.php
@@ -25,11 +25,11 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026052100;
+$plugin->version   = 2026061000;
 $plugin->requires  = 2024100700;
 $plugin->component = 'block_blc_modules';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '4.5.15';
+$plugin->release = '4.5.16';
 $plugin->dependencies = [
     'mod_scorm' => 2024100700,
 ];


### PR DESCRIPTION
moodle_url already handles URL encoding internally via out(). Using urlencode() beforehand caused parameters like scormurl to be encoded twice, potentially breaking API communication with the BLC server.

Affected methods:
- fetch_scorm_data, fetch_accessibility_document
- cleanup_temp_files, cleanup_temp_doc_files
- get_blc_modules_scormdelete
- add_doc.php (API call + cleanup)
- bulk_update_processor.php (bulk update temp URL)