### PR TITLE
Use Local SCORM URL API instead of Direct Query for API Key Mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to `block_blc_modules` for Moodle 4.5 are documented in this
 
 ---
 
+## [4.5.17] — 2026-06-11
+
+### Changed
+- `ensure_api_key_mapping()` now calls the `local_scormurl_update_scorm_mapping` web service instead of writing directly to the `block_scorm_apikey` table. This also eliminates unnecessary missing-table error logs that appeared when the `block_scorm_apikey` table was absent.
+
+### Removed
+- Missing table warning alert from UI, which were only used by the old direct-DB access.
+
+---
+
 ## [4.5.16] — 2026-06-10
 
 ### Fixed

--- a/classes/external/blcservice.php
+++ b/classes/external/blcservice.php
@@ -38,7 +38,6 @@ use core_external\external_value;
 use core_external\external_function_parameters;
 use core_external\external_single_structure;
 use core_external\external_multiple_structure;
-use core\notification;
 use Exception;
 use moodle_url;
 use stdClass;
@@ -55,13 +54,6 @@ require_once($CFG->dirroot.'/mod/resource/lib.php');
  * Class blcservice
  */
 class blcservice extends external_api {
-    /**
-     * Prevent duplicate dependency warnings in a single request.
-     *
-     * @var bool
-     */
-    private static $missingscormpackagenoticeshown = false;
-
     /**
      * Returns description of method parameters for check blc modules URLs.
      *
@@ -611,7 +603,7 @@ class blcservice extends external_api {
 
                     // Ensure this SCORM ID is mapped to the API key for future access.
                     if (!empty($scormdata['scormid'])) {
-                        self::ensure_api_key_mapping($params['apikey'], (int) $scormdata['scormid']);
+                        self::ensure_api_key_mapping($params['apikey'], (int) $scormdata['scormid'], $token, $domainname);
                     }
 
                     // Clean up temporary files.
@@ -941,102 +933,38 @@ class blcservice extends external_api {
     }
 
     /**
-     * Ensure SCORM ID is mapped to API key in block_scorm_apikey table.
+     * Ensure SCORM ID is mapped to API key via local_scormurl API.
      * This allows the SCORM package to be accessible via the API key.
      *
      * @param string $apikey API key
      * @param int $scormid SCORM package ID
+     * @param string $token Web service token
+     * @param string $domainname BLC domain name
      */
-    public static function ensure_api_key_mapping(string $apikey, int $scormid): void {
-        global $DB;
-
+    public static function ensure_api_key_mapping(string $apikey, int $scormid, string $token, string $domainname): void {
         if (empty($scormid) || empty($apikey)) {
             return;
         }
 
         try {
-            // TO DO: Pindahkan ke block_scorm_package dan buat API untuk mengelola mapping ini
-            // Check if mapping record exists for this API key.
-            $mapping = $DB->get_record('block_scorm_apikey', ['api_key' => $apikey]);
+            $functionname = 'local_scormurl_update_scorm_mapping';
+            $serverurl = new moodle_url($domainname . '/webservice/rest/server.php', [
+                'wstoken' => $token,
+                'wsfunction' => $functionname,
+                'apikey' => $apikey,
+                'scormid' => $scormid,
+                'moodlewsrestformat' => 'json',
+            ]);
 
-            if ($mapping) {
-                // Parse existing SCORM IDs.
-                $existingids = !empty($mapping->scormids)
-                    ? array_map('intval', explode(',', $mapping->scormids))
-                    : [];
+            $curl = new blccurl_helper();
+            $curl->set_header('Content-Type: application/json; charset=utf-8');
+            $curl->post($serverurl->out(false), '', ['CURLOPT_FAILONERROR' => true]);
 
-                // Add new ID if not already present.
-                if (!in_array($scormid, $existingids)) {
-                    $existingids[] = $scormid;
-                    $mapping->scormids = implode(',', array_unique($existingids));
-                    $mapping->timemodified = time();
-                    $DB->update_record('block_scorm_apikey', $mapping);
-
-                    debugging('BLC Modules: Added SCORM ID ' . $scormid . ' to API key mapping');
-
-                    // Invalidate cache for this API key.
-                    if (class_exists('\local_scormurl\helpers\cache_manager')) {
-                        \local_scormurl\helpers\cache_manager::invalidate_api_key_mapping($apikey);
-                    }
-                }
-            } else {
-                // Create new mapping record.
-                $newmapping = new stdClass();
-                $newmapping->api_key = $apikey;
-                $newmapping->scormids = (string)$scormid;
-                $newmapping->timecreated = time();
-                $newmapping->timemodified = time();
-                $DB->insert_record('block_scorm_apikey', $newmapping);
-
-                debugging('BLC Modules: Created new API key mapping for SCORM ID ' . $scormid);
-            }
+            debugging('BLC Modules: Updated SCORM mapping via API for SCORM ID ' . $scormid);
         } catch (Throwable $e) {
-            if (self::is_missing_scorm_apikey_table_exception($e)) {
-                self::notify_missing_scorm_package_dependency();
-                return;
-            }
-
-            debugging('BLC Modules: Failed to update API key mapping: ' . $e->getMessage());
+            debugging('BLC Modules: Failed to update API key mapping via API: ' . $e->getMessage());
             // Don't throw exception - this is not critical for module creation.
         }
-    }
-
-    /**
-     * Show a clear non-critical warning when dependency table is unavailable.
-     */
-    private static function notify_missing_scorm_package_dependency(): void {
-        if (self::$missingscormpackagenoticeshown) {
-            return;
-        }
-
-        self::$missingscormpackagenoticeshown = true;
-        $message = get_string('missingscormpackagedependency', 'block_blc_modules', 'block_scorm_apikey');
-
-        if (!(defined('CLI_SCRIPT') && CLI_SCRIPT)) {
-            notification::warning($message);
-        }
-
-        debugging('BLC Modules: ' . $message, DEBUG_NORMAL);
-    }
-
-    /**
-     * Detect missing table exception for block_scorm_apikey.
-     *
-     * @param Throwable $exception
-     * @return bool
-     */
-    private static function is_missing_scorm_apikey_table_exception(Throwable $exception): bool {
-        $needle = 'block_scorm_apikey';
-
-        if (strpos(strtolower($exception->getMessage()), $needle) !== false) {
-            return true;
-        }
-
-        if (property_exists($exception, 'debuginfo') && !empty($exception->debuginfo)) {
-            return strpos(strtolower((string)$exception->debuginfo), $needle) !== false;
-        }
-
-        return false;
     }
 
     /**

--- a/scorm_load_processor.php
+++ b/scorm_load_processor.php
@@ -317,7 +317,7 @@ switch ($action) {
             blcservice::record_blc_module($courseid, $sectionnumber, $scormcm, $scormdata, $url);
 
             if (!empty($scormdata['scormid'])) {
-                blcservice::ensure_api_key_mapping($apikey, (int)$scormdata['scormid']);
+                blcservice::ensure_api_key_mapping($apikey, (int)$scormdata['scormid'], $token, $domainname);
             }
 
             blcservice::cleanup_temp_files($apikey, $url, $token, $domainname);

--- a/version.php
+++ b/version.php
@@ -25,11 +25,11 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026061000;
+$plugin->version   = 2026061100;
 $plugin->requires  = 2024100700;
 $plugin->component = 'block_blc_modules';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '4.5.16';
+$plugin->release = '4.5.17';
 $plugin->dependencies = [
     'mod_scorm' => 2024100700,
 ];


### PR DESCRIPTION
This pull request updates the `block_blc_modules` plugin to version 4.5.17, focusing on improving how SCORM API key mappings are managed. The main change is that the mapping is now handled through a dedicated web service (`local_scormurl_update_scorm_mapping`) instead of direct database writes, which also eliminates unnecessary error logs and UI alerts when the mapping table is missing.

**API Key Mapping Improvements:**
* The `ensure_api_key_mapping()` method now calls the `local_scormurl_update_scorm_mapping` web service instead of directly modifying the `block_scorm_apikey` table. This change removes the dependency on the table's existence and prevents missing-table error logs. [[1]](diffhunk://#diff-2a28a9bbf7eac9976631e536236cb7d648d5d090e6ca53f193a732e7a0b6db06L944-L1041) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R16)
* All calls to `ensure_api_key_mapping()` have been updated to pass the required web service token and domain name parameters. [[1]](diffhunk://#diff-2a28a9bbf7eac9976631e536236cb7d648d5d090e6ca53f193a732e7a0b6db06L614-R606) [[2]](diffhunk://#diff-87dcf0195c27d804e0432c8ccae18e9df143aee8df67dea0ff2f0e939a1baf42L320-R320)

**Code and UI Clean-up:**
* Removed the logic and UI notifications related to missing `block_scorm_apikey` table warnings, as these are no longer relevant with the move to API-based mapping. [[1]](diffhunk://#diff-2a28a9bbf7eac9976631e536236cb7d648d5d090e6ca53f193a732e7a0b6db06L58-L64) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R16)
* Unused imports and private variables related to the old notification mechanism have been removed. [[1]](diffhunk://#diff-2a28a9bbf7eac9976631e536236cb7d648d5d090e6ca53f193a732e7a0b6db06L41) [[2]](diffhunk://#diff-2a28a9bbf7eac9976631e536236cb7d648d5d090e6ca53f193a732e7a0b6db06L58-L64)

**Release and Versioning:**
* Bumped the plugin version to 4.5.17 and updated the release date in `version.php` and `CHANGELOG.md`. [[1]](diffhunk://#diff-0dc418129946563e59bb69680a5ef0ded4329ed9e56e3d295c25e12ea726726bL28-R32) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R16)